### PR TITLE
community: fix AttributeError: 'YandexGPT' object has no attribute '_grpc_metadata'

### DIFF
--- a/libs/community/langchain_community/llms/yandex.py
+++ b/libs/community/langchain_community/llms/yandex.py
@@ -92,13 +92,13 @@ class _BaseYandexGPT(Serializable):
             raise ValueError("Either 'YC_API_KEY' or 'YC_IAM_TOKEN' must be provided.")
 
         if values["iam_token"]:
-            values["_grpc_metadata"] = [
+            cls._grpc_metadata = [
                 ("authorization", f"Bearer {values['iam_token'].get_secret_value()}")
             ]
             if values["folder_id"]:
-                values["_grpc_metadata"].append(("x-folder-id", values["folder_id"]))
+                cls._grpc_metadata.append(("x-folder-id", values["folder_id"]))
         else:
-            values["_grpc_metadata"] = (
+            cls._grpc_metadata = (
                 ("authorization", f"Api-Key {values['api_key'].get_secret_value()}"),
             )
         if values["model_uri"] == "" and values["folder_id"] == "":
@@ -108,7 +108,7 @@ class _BaseYandexGPT(Serializable):
                 f"gpt://{values['folder_id']}/{values['model_name']}/{values['model_version']}"
             )
         if values["disable_request_logging"]:
-            values["_grpc_metadata"].append(
+            cls._grpc_metadata.append(
                 (
                     "x-data-logging-enabled",
                     "false",


### PR DESCRIPTION
**Description:** When accessing the yandexgpt api, the user could encounter the error “ ‘YandexGPT’ object has no attribute ‘_grpc_metadata’ ”. The problem was that the initialization of this protected field was incorrect and it was impossible to get the value of this attribute. I made such changes in the _BaseYandexGPT base class that now everything works correctly.
**Issue:** #24049
**Dependencies:** None
**Twitter handle:**  None